### PR TITLE
fixed PostgreSQL DDL for concept_name

### DIFF
--- a/inst/ddl/5.4/postgresql/OMOPCDM_postgresql_5.4_ddl.sql
+++ b/inst/ddl/5.4/postgresql/OMOPCDM_postgresql_5.4_ddl.sql
@@ -416,7 +416,7 @@ CREATE TABLE @cdmDatabaseSchema.CDM_SOURCE (
 --HINT DISTRIBUTE ON RANDOM
 CREATE TABLE @cdmDatabaseSchema.CONCEPT (
 			concept_id integer NOT NULL,
-			concept_name varchar(255) NOT NULL,
+			concept_name text NOT NULL,
 			domain_id varchar(20) NOT NULL,
 			vocabulary_id varchar(20) NOT NULL,
 			concept_class_id varchar(20) NOT NULL,


### PR DESCRIPTION
`VARCHAR(255)` is not enough for many concepts.

For example, concept code 829971 from RxNorm is >300 characters long:  https://bioportal.bioontology.org/ontologies/RXNORM?p=classes&conceptid=829986